### PR TITLE
Fix/dataclasses dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bumpversion==0.5.3
+dataclasses==0.7; python_version == '3.6'
 hexbytes==0.2.0
 jsonschema==3.2.0
 polyswarm-artifact==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     python_requires='>=3.6,<4',
     install_requires=[
         'hexbytes==0.2.0',
+        'dataclasses==0.7; python_version=="3.6"',
         'jsonschema==3.2.0',
         'polyswarm-artifact==1.3.2',
         'web3==5.4.0'
@@ -31,7 +32,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,7 @@
 [tox]
 envlist = py36,py37
 
-[testenv:py36]
-deps = -rrequirements.txt
-       dataclasses >= 0.7
-commands =
-    pytest -s --cov=polyswarmtransaction
-
-[testenv:p37]
+[testenv]
 deps = -rrequirements.txt
 commands =
     pytest -s --cov=polyswarmtransaction


### PR DESCRIPTION
`dataclasses` is already part of Python 3.7, while [this package included in the dependencies](https://pypi.org/project/dataclasses/) is a back-port for Python 3.6.

- Using conditional requirement.
- Removing Python 3.5, as it does not support `dataclasses` and there's no environment for tox (assuming we don't want to support it).