### PR TITLE
WrongPayloadError to inform a signed transaction with wrong payload

### DIFF
--- a/src/polyswarmtransaction/exceptions.py
+++ b/src/polyswarmtransaction/exceptions.py
@@ -11,10 +11,16 @@ class InvalidSignatureError(PolySwarmTransactionException):
 
 
 class WrongSignatureError(PolySwarmTransactionException):
+    """
+    To be raised when the payload signature does not match
+    """
     pass
 
 
 class WrongPayloadError(PolySwarmTransactionException):
+    """
+    To be raised when the signed payload does not comply with the transaction payload needed
+    """
     pass
 
 

--- a/src/polyswarmtransaction/exceptions.py
+++ b/src/polyswarmtransaction/exceptions.py
@@ -14,6 +14,10 @@ class WrongSignatureError(PolySwarmTransactionException):
     pass
 
 
+class WrongPayloadError(PolySwarmTransactionException):
+    pass
+
+
 class MissingTransactionError(PolySwarmTransactionException):
     pass
 


### PR DESCRIPTION
Adds a new exception to inform that the correctly signed transaction contains a bad payload.