### PR TITLE
load_key(private_key) accepting a PrivateKey instance directly

### DIFF
--- a/src/polyswarmtransaction/transaction.py
+++ b/src/polyswarmtransaction/transaction.py
@@ -58,7 +58,7 @@ class Transaction:
         return json.dumps(body)
 
     @staticmethod
-    def load_key(private_key: HexBytes) -> PrivateKey:
+    def load_key(private_key: Union[HexBytes, PrivateKey]) -> PrivateKey:
         if isinstance(private_key, PrivateKey):
             # Lifts the need to convert to bytes and back to PrivateKey
             return private_key

--- a/src/polyswarmtransaction/transaction.py
+++ b/src/polyswarmtransaction/transaction.py
@@ -59,6 +59,10 @@ class Transaction:
 
     @staticmethod
     def load_key(private_key: HexBytes) -> PrivateKey:
+        if isinstance(private_key, PrivateKey):
+            # Lifts the need to convert to bytes and back to PrivateKey
+            return private_key
+
         try:
             return PrivateKey(private_key)
         except ValidationError:


### PR DESCRIPTION
Optimizes a costly operation that occurs a lot during Locust loadtests